### PR TITLE
Make social_image_link.rs open in new tab

### DIFF
--- a/src/components/social_image_link.rs
+++ b/src/components/social_image_link.rs
@@ -16,7 +16,7 @@ pub fn SocialImageLink(props: &Props) -> Html {
     let img_alt = format!("An image link to {}", social.get_name());
 
     html! {
-        <a href={href} class="w-fit h-fit aspect-square">
+        <a href={href} target="_blank" rel="noopener noreferrer" class="w-fit h-fit aspect-square">
             <img src={img_src} alt={img_alt} class="block m-auto h-10 aspect-square drop-shadow-2xl" />
         </a>
     }


### PR DESCRIPTION
Social image links don't open in a new tab. Literally unusable. I fixed that for you uwu.